### PR TITLE
Bugfix FlutterForegroundService.java regarding subtext

### DIFF
--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
@@ -52,7 +52,7 @@ public class FlutterForegroundService extends Service {
                         .setUsesChronometer(bundle.getBoolean("chronometer"))
                         .setOngoing(true);
 
-                if (bundle.getString("subtext") != null && bundle.getString("subtext").isEmpty()) {
+                if (bundle.getString("subtext") != null && !bundle.getString("subtext").isEmpty()) {
                     builder.setSubText(bundle.getString("subtext"));
                 }
 


### PR DESCRIPTION
Just a small bugfix - it should be showing, if NON empty. If it is empty, there is nothing to show...