### PR TITLE
Close app when app stop

### DIFF
--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
@@ -131,7 +131,7 @@ public class FlutterForegroundPlugin implements MethodCallHandler {
 
         Intent intent = new Intent(activity, FlutterForegroundService.class);
         intent.setAction(STOP_FOREGROUND_ACTION);
-        activity.stopService(intent);
+        activity.startService(intent);
 
         callbackChannel.invokeMethod("onStopped", null);
     }


### PR DESCRIPTION
# Situation

In AndroidMainifest set
```
<service android:name="changjoopark.com.flutter_foreground_plugin.FlutterForegroundService" android:stopWithTask="true"/>
```

Foreground service will kill after app is closed by user.

However, other flutter plugin(ex: GPS) still send data to flutter channel. It will cause flutter continually throw `Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: flutter.baseflow.com/geolocator_updates. Response ID: 0` error message.

# Workaround
If foreground service is not closed by user(which means closed by system), close app as well.
