### PR TITLE
[Fix] Intent may be null

### DIFF
--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
@@ -4,9 +4,6 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
-import android.widget.RemoteViews;
-
-import java.util.concurrent.ScheduledExecutorService;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -47,27 +44,27 @@ public class FlutterForegroundPlugin implements MethodCallHandler {
 
     @Override
     public void onMethodCall(MethodCall call, Result result) {
-                switch (call.method) {
-                    case "startForegroundService":
-                        final Boolean holdWakeLock = call.argument("holdWakeLock");
-                        final String icon = call.argument("icon");
-                        final int color = call.argument("color");
-                        final String title = call.argument("title");
-                        final String content = call.argument("content");
-                        final String subtext = call.argument("subtext");
-                        final Boolean chronometer = call.argument("chronometer");
-                        final Boolean stopAction = call.argument("stop_action");
-                        final String stopIcon = call.argument("stop_icon");
-                        final String stopText = call.argument("stop_text");
+        switch (call.method) {
+            case "startForegroundService":
+                final Boolean holdWakeLock = call.argument("holdWakeLock");
+                final String icon = call.argument("icon");
+                final int color = call.argument("color");
+                final String title = call.argument("title");
+                final String content = call.argument("content");
+                final String subtext = call.argument("subtext");
+                final Boolean chronometer = call.argument("chronometer");
+                final Boolean stopAction = call.argument("stop_action");
+                final String stopIcon = call.argument("stop_icon");
+                final String stopText = call.argument("stop_text");
 
-                        launchForegroundService(icon, color, title, content, subtext, chronometer, stopAction, stopIcon, stopText);
-                        result.success("startForegroundService");
-                        break;
-                    case "stopForegroundService":
-                        stopForegroundService();
-                        result.success("stopForegroundService");
-                        break;
-                    case "setServiceMethodInterval":
+                launchForegroundService(icon, color, title, content, subtext, chronometer, stopAction, stopIcon, stopText);
+                result.success("startForegroundService");
+                break;
+            case "stopForegroundService":
+                stopForegroundService();
+                result.success("stopForegroundService");
+                break;
+            case "setServiceMethodInterval":
                 if (call.argument("seconds") == null) {
                     result.notImplemented();
                     break;

--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
@@ -1,6 +1,5 @@
 package changjoopark.com.flutter_foreground_plugin;
 
-import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -61,7 +60,7 @@ public class FlutterForegroundService extends Service {
                     stopSelf.setAction(ACTION_STOP_SERVICE);
 
                     PendingIntent pStopSelf = PendingIntent
-                            .getService(this, 0, stopSelf ,PendingIntent.FLAG_CANCEL_CURRENT);
+                            .getService(this, 0, stopSelf, PendingIntent.FLAG_CANCEL_CURRENT);
                     builder.addAction(getNotificationIcon(bundle.getString("stop_icon")),
                             bundle.getString("stop_text"),
                             pStopSelf);

--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundService.java
@@ -9,11 +9,13 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
 
 public class FlutterForegroundService extends Service {
+    private static String TAG = "FlutterForegroundService";
     public static int ONGOING_NOTIFICATION_ID = 1;
     public static final String NOTIFICATION_CHANNEL_ID = "CHANNEL_ID";
     public static final String ACTION_STOP_SERVICE = "STOP";
@@ -22,11 +24,16 @@ public class FlutterForegroundService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        if (intent.getAction() == null) {
-            return START_STICKY;
+        if (intent == null) {
+            Log.d(TAG, "onStartCommand: Intent is null");
+            return START_NOT_STICKY;
         }
-
+        if (intent.getAction() == null) {
+            Log.d(TAG, "onStartCommand: Intent action is null");
+            return START_NOT_STICKY;
+        }
         final String action = intent.getAction();
+        Log.d(TAG, String.format("onStartCommand: %s", action));
 
         switch (action) {
             case FlutterForegroundPlugin.START_FOREGROUND_ACTION:
@@ -82,15 +89,15 @@ public class FlutterForegroundService extends Service {
                 break;
         }
 
-        return START_STICKY;
+        return START_NOT_STICKY;
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        android.util.Log.d("FlutterForegroundService", "onDestroy");
+        Log.d(TAG, "onDestroy");
         if (!userStopForegroundService) {
-            android.util.Log.d("FlutterForegroundService", "User close app, kill current process to avoid memory leak in other plugin.");
+            Log.d(TAG, "User close app, kill current process to avoid memory leak in other plugin.");
             android.os.Process.killProcess(android.os.Process.myPid());
         }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
-import 'dart:async';
+import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_foreground_plugin/flutter_foreground_plugin.dart';
 
 void main() => runApp(MyApp());
@@ -41,6 +41,12 @@ class _MyAppState extends State<MyApp> {
                   await FlutterForegroundPlugin.stopForegroundService();
                 },
               ),
+              RaisedButton(
+                child: Text("Force Crash"),
+                onPressed: () {
+                  exit(1);
+                },
+              )
             ],
           ),
         ),


### PR DESCRIPTION
Issue: #18 

Does anybody know how to reproduce this issue?
I notice it by crash report, but I cannot reproduce it by myself.

Document say:
> if this service's process is killed while it is started (after returning from onStartCommand(Intent, int, int)), then leave it in the started state but don't retain this delivered intent.
...
if there are not any pending start commands to be delivered to the service, it will be called with a null intent object, so you must take care to check for this.


Should I start foreground service again when intent is null?

Reference:
https://stackoverflow.com/questions/8421430/reasons-that-the-passed-intent-would-be-null-in-onstartcommand
https://developer.android.com/reference/android/app/Service.html#START_STICKY