### PR TITLE
Fix private accessing (Setting constructor to public)

### DIFF
--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
@@ -35,7 +35,7 @@ public class FlutterForegroundPlugin implements FlutterPlugin, MethodCallHandler
     private Runnable runnable;
     private Handler handler = new Handler(Looper.getMainLooper());
 
-    private FlutterForegroundPlugin() {}
+    public FlutterForegroundPlugin() {}
 
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {


### PR DESCRIPTION
private constructor `FlutterForegroundPlugin` is causing build failure. Setting the constructor to being a public class fixed the issue