### PR TITLE
Update FlutterForegroundPlugin.java

### DIFF
--- a/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
+++ b/android/src/main/java/changjoopark/com/flutter_foreground_plugin/FlutterForegroundPlugin.java
@@ -35,7 +35,7 @@ public class FlutterForegroundPlugin implements FlutterPlugin, MethodCallHandler
     private Runnable runnable;
     private Handler handler = new Handler(Looper.getMainLooper());
 
-    private FlutterForegroundPlugin() {}
+    public FlutterForegroundPlugin() {}
 
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {


### PR DESCRIPTION
Hi,

I encountered an issue with the FlutterForegroundPlugin while working on my project, and I believe I found a fix for it. 

The issue was that the FlutterForegroundPlugin constructor had private access, causing a compilation error when attempting to create a new instance of the plugin in GeneratedPluginRegistrant.java.

To fix this, I modified the FlutterForegroundPlugin constructor to have public access, and was able to successfully build my project.

Please review my changes and let me know if they are acceptable.

Thanks,
Hoshmand